### PR TITLE
Fixed minor issue in php set timezone

### DIFF
--- a/ansible/roles/php7.0/tasks/main.yml
+++ b/ansible/roles/php7.0/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: set timezone in php.ini
   lineinfile:
-    path: /etc/php/7.0/fpm/php.ini
+    dest: /etc/php/7.0/fpm/php.ini
     regexp: ';date\.timezone ='
     line: 'date.timezone = Europe/Berlin'
   become: true


### PR DESCRIPTION
In Ansible 2.2 there is no path parameter for the task lineinfile, but dest works fine.